### PR TITLE
Add docker-compose file and setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /explorer/pplbkp/
 *.zip
 *.gz
+*.sql

--- a/README.md
+++ b/README.md
@@ -8,3 +8,36 @@ build a public database of product data.  For more information, please
 visit http://product.okfn.org.
 
 The code is written in PHP with a MySQL database backend.
+
+
+Dockerized Development Instance
+-------------------------------
+
+### Prerequisites
+
+Make sure you have [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed.
+
+### Clone this repository
+
+`git clone https://github.com/okfn/product-browser-web.git`
+
+### Run the setup script
+
+```
+cd product-browser-web/scripts/dockerfiles
+wget -O - http://dfowler.sixbit.org/products.sql.gz | \
+  gunzip -c > pod_mysql/products.sql
+docker-compose --project-name pod up
+```
+
+### Import the database
+
+```
+docker exec pod_db_1 sh -c \
+  'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" \
+  "$MYSQL_DATABASE" < products.sql'
+```
+
+### Access the local development instance
+
+Your local copy of Product Open Data should now be running on port 18080 of your Docker host.

--- a/scripts/dockerfiles/docker-compose.yml
+++ b/scripts/dockerfiles/docker-compose.yml
@@ -1,0 +1,14 @@
+db:
+  build: pod_mysql
+  environment:
+    - MYSQL_ROOT_PASSWORD=somerootpw
+    - MYSQL_PASSWORD=someuserpw
+
+web:
+  build: pod_php_apache
+  ports:
+    - "18080:80"
+  volumes:
+    - ../../explorer/:/var/www/html/
+  links:
+    - db:pod_db


### PR DESCRIPTION
This commit adds a docker-compose file for easier setup of a local development instance. It also updates the README to include instructions how to set the project up using Docker and Docker Compose and how to import the database. In addition, SQL files are now ignored by git.
